### PR TITLE
Remove the dirty hack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ project(OTBTensorflow)
 
 # Use Tensorflow, or not
 option(OTB_USE_TENSORFLOW "Enable Tensorflow dependent applications" OFF)
+set(CMAKE_CXX_STANDARD 17)
 
 if(OTB_USE_TENSORFLOW)
   message("Tensorflow support enabled")

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,20 +104,7 @@ RUN apt-get update -y \
  && git clone https://gitlab.orfeo-toolbox.org/orfeotoolbox/otb.git \
  && cd otb && git checkout $OTB
 
-# <---------------------------------------- Begin dirty hack
-# This is a dirty hack for release 4.0.0alpha
-# We have to wait that OTB moves from C++14 to C++17
-# See https://gitlab.orfeo-toolbox.org/orfeotoolbox/otb/-/issues/2338
-RUN cd /src/otb/otb \
- && sed -i 's/CMAKE_CXX_STANDARD 14/CMAKE_CXX_STANDARD 17/g' CMakeLists.txt \
- && echo "" > Modules/Core/ImageManipulation/test/CMakeLists.txt \
- && echo "" > Modules/Core/Conversion/test/CMakeLists.txt \
- && echo "" > Modules/Core/Indices/test/CMakeLists.txt \
- && echo "" > Modules/Core/Edge/test/CMakeLists.txt \
- && echo "" > Modules/Core/ImageBase/test/CMakeLists.txt \
- && echo "" > Modules/Learning/DempsterShafer/test/CMakeLists.txt \
-# <---------------------------------------- End dirty hack
- && cd .. \
+RUN cd /src/otb/ \
  && mkdir -p build \
  && cd build \
  && if $OTBTESTS; then \

--- a/setup.py
+++ b/setup.py
@@ -32,4 +32,10 @@ setuptools.setup(
               "deep learning",
               "machine learning"
               ],
+    install_requires=[
+        "deprecated",
+        "tensorflow",
+        "numpy",
+        "tqdm",
+    ]
 )


### PR DESCRIPTION
Hi,
I see that there is a "dirty hack" in the Dockerfile.
I see that your module uses C++17 and OTB doesn't fully support it.
This PR set C++ 17 only for your module in CMakefile. So, it removed the dirty hack in the Dockerfile.

I have also added Python dependencies in the setup.py.
I have split the PR in 3 distinct commits if you prefer cherry-pick it.